### PR TITLE
Fix include header guard

### DIFF
--- a/cpu.h
+++ b/cpu.h
@@ -5,7 +5,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-#ifndef _cpu_c_
+#ifndef _cpu_h_
 #define _cpu_h_
 
 void cpuInit();


### PR DESCRIPTION
Hello!

My compiler was barking at me over this include guard. Doesn't really break the build, but I figure it's something to address.