### PR TITLE
Use platform-dependent macro for noinline attribute

### DIFF
--- a/audio_fds.c
+++ b/audio_fds.c
@@ -76,7 +76,7 @@ void fdsAudioInit()
 	fds_apu.wavWrite = false;
 }
 
-__attribute__ ((noinline)) void fdsAudioCycle()
+FIXNES_NOINLINE void fdsAudioCycle()
 {
 	if(fds_apu.wavWrite)
 		return;
@@ -141,7 +141,7 @@ void fdsAudioClockTimers()
 	}
 }
 
-__attribute__ ((noinline)) void fdsAudioMasterUpdate()
+FIXNES_NOINLINE void fdsAudioMasterUpdate()
 {
 	if(fds_apu.masterEnable)
 	{

--- a/audio_fds.h
+++ b/audio_fds.h
@@ -8,10 +8,12 @@
 #ifndef _AUDIO_FDS_H_
 #define _AUDIO_FDS_H_
 
+#include "common.h"
+
 void fdsAudioInit();
-__attribute__ ((noinline)) void fdsAudioCycle();
+FIXNES_NOINLINE void fdsAudioCycle();
 void fdsAudioClockTimers();
-__attribute__ ((noinline)) void fdsAudioMasterUpdate();
+FIXNES_NOINLINE void fdsAudioMasterUpdate();
 void fdsAudioSet8(uint8_t reg, uint8_t val);
 void fdsAudioSetWave(uint8_t pos, uint8_t val);
 uint8_t fdsAudioGet8(uint8_t reg);

--- a/audio_mmc5.c
+++ b/audio_mmc5.c
@@ -122,7 +122,7 @@ void mmc5AudioPCMWrite(uint8_t val)
 
 static uint8_t mmc5_p1Out = 0, mmc5_p2Out = 0;
 
-__attribute__ ((noinline)) void mmc5AudioCycle()
+FIXNES_NOINLINE void mmc5AudioCycle()
 {
 	if(mmc5_apu.p1LengthCtr && (mmc5_apu.reg[0x15] & P1_ENABLE))
 	{
@@ -137,7 +137,7 @@ __attribute__ ((noinline)) void mmc5AudioCycle()
 	mmc5Out = mmc5_p1Out + mmc5_p2Out;
 }
 
-__attribute__ ((noinline)) void mmc5AudioLenCycle()
+FIXNES_NOINLINE void mmc5AudioLenCycle()
 {
 	if(mmc5_apu.modeCurCtr)
 		mmc5_apu.modeCurCtr--;

--- a/audio_mmc5.h
+++ b/audio_mmc5.h
@@ -8,12 +8,14 @@
 #ifndef _audio_mmc5_h_
 #define _audio_mmc5_h_
 
+#include "common.h"
+
 void mmc5AudioInit();
-__attribute__ ((noinline)) void mmc5AudioCycle();
+FIXNES_NOINLINE void mmc5AudioCycle();
 void mmc5AudioClockTimers();
 void mmc5AudioSet8(uint8_t reg, uint8_t val);
 uint8_t mmc5AudioGet8(uint8_t reg);
-__attribute__ ((noinline)) void mmc5AudioLenCycle();
+FIXNES_NOINLINE void mmc5AudioLenCycle();
 void mmc5AudioPCMWrite(uint8_t val);
 
 extern uint8_t mmc5Out;

--- a/audio_s5b.c
+++ b/audio_s5b.c
@@ -242,7 +242,7 @@ void s5BAudioSet8(uint16_t addr, uint8_t val)
 	}
 }
 
-__attribute__((noinline)) void s5BAudioCycle()
+FIXNES_NOINLINE void s5BAudioCycle()
 {
 	uint16_t out = 0;
 	uint8_t i;

--- a/audio_s5b.h
+++ b/audio_s5b.h
@@ -8,10 +8,12 @@
 #ifndef _AUDIO_s5B_H_
 #define _AUDIO_s5B_H_
 
+#include "common.h"
+
 void s5BAudioInit();
 void s5BAudioClockTimers();
 void s5BAudioSet8(uint16_t addr, uint8_t val);
-__attribute__((noinline)) void s5BAudioCycle();
+FIXNES_NOINLINE void s5BAudioCycle();
 
 extern uint16_t s5BOut;
 

--- a/audio_vrc6.c
+++ b/audio_vrc6.c
@@ -49,7 +49,7 @@ void vrc6AudioInit()
 	//printf("VRC6 Audio Inited!\n");
 }
 
-__attribute__ ((noinline)) void vrc6AudioCycle()
+FIXNES_NOINLINE void vrc6AudioCycle()
 {
 	if(vrc6_apu.p1enable)
 		vrc6_apu.p1Out = (vrc6_apu.p1const || vrc6_apu.p1Cycle <= vrc6_apu.p1Duty) ? vrc6_apu.p1Vol : 0;

--- a/audio_vrc6.h
+++ b/audio_vrc6.h
@@ -8,8 +8,10 @@
 #ifndef _AUDIO_VRC6_H_
 #define _AUDIO_VRC6_H_
 
+#include "common.h"
+
 void vrc6AudioInit();
-__attribute__ ((noinline)) void vrc6AudioCycle();
+FIXNES_NOINLINE void vrc6AudioCycle();
 void vrc6AudioClockTimers();
 void vrc6AudioSet8(uint16_t addr, uint8_t val);
 

--- a/audio_vrc7.c
+++ b/audio_vrc7.c
@@ -362,7 +362,7 @@ static int32_t vrc7GetOut(vrc7chan_t *chan, vrc7slot_t *slot, uint8_t slotNum, u
 	return slot->fbOut;
 }
 
-__attribute__((noinline)) void vrc7AudioCycle()
+FIXNES_NOINLINE void vrc7AudioCycle()
 {
 	vrc7Out = 0;
 	//update am and fm for all chans

--- a/audio_vrc7.h
+++ b/audio_vrc7.h
@@ -8,8 +8,10 @@
 #ifndef _AUDIO_VRC7_H_
 #define _AUDIO_VRC7_H_
 
+#include "common.h"
+
 void vrc7AudioInit();
-__attribute__((noinline)) void vrc7AudioCycle();
+FIXNES_NOINLINE void vrc7AudioCycle();
 void vrc7AudioSet8(uint8_t addr, uint8_t val);
 
 extern int32_t vrc7Out;

--- a/common.h
+++ b/common.h
@@ -1,0 +1,10 @@
+#ifndef _common_h_
+#define _common_h_
+
+#ifdef _MSC_VER
+#define FIXNES_NOINLINE __declspec(noinline)
+#else
+#define FIXNES_NOINLINE __attribute__((noinline))
+#endif
+
+#endif


### PR DESCRIPTION
I have trouble compiling with MSVC wherever the `__attribute__` qualifier is used. Here I propose a `common.h` header with a platform-dependent macro instead.