### PR TITLE
Fix macro redefinition error

### DIFF
--- a/audio_vrc7.c
+++ b/audio_vrc7.c
@@ -122,8 +122,12 @@ static struct {
 	uint8_t reg;
 } vrc7_apu;
 
+#ifndef M_PI
 #define M_PI 3.14159265358979323846
+#endif
+#ifndef M_2PI
 #define M_2PI 6.28318530717958647692
+#endif
 
 void vrc7AudioInit()
 {


### PR DESCRIPTION
On macOS defining M_PI causes a redefinition error, so guarding the macro with #ifdef...#endif should prevent this error, and the added precision shouldn't cause any unwanted issues.