### PR TITLE
fix build issue with msys2 openal and freeglut

### DIFF
--- a/build_msys32.sh
+++ b/build_msys32.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-gcc -DWINDOWS_BUILD -DZIPSUPPORT main.c apu.c audio.c audio_fds.c audio_mmc5.c audio_vrc6.c audio_vrc7.c audio_n163.c audio_s5b.c alhelpers.c cpu.c ppu.c mem.c input.c mapper.c mapperList.c fm2play.c vrc_irq.c mapper/*.c unzip/*.c -DFREEGLUT_STATIC -lfreeglut_static -lopenal32 -lopengl32 -lglu32 -lgdi32 -lwinmm -lz -Wall -Wextra -DDO_INLINE_ATTRIBS=1 -Wno-attributes -O3 -flto -s -o fixNES
+gcc -DWINDOWS_BUILD -DZIPSUPPORT main.c apu.c audio.c audio_fds.c audio_mmc5.c audio_vrc6.c audio_vrc7.c audio_n163.c audio_s5b.c alhelpers.c cpu.c ppu.c mem.c input.c mapper.c mapperList.c fm2play.c vrc_irq.c mapper/*.c unzip/*.c -DFREEGLUT -lfreeglut -lopenal -lopengl32 -lglu32 -lgdi32 -lwinmm -lz -Wall -Wextra -DDO_INLINE_ATTRIBS=1 -Wno-attributes -O3 -flto -s -o fixNES


### PR DESCRIPTION
due to a change in msys2 gcc 13(may be wrong) and the msys2 package for openal-soft not using -lopenal32 anymore i had tp remove the static arguements and update the linker libnames